### PR TITLE
treat whitespace inside quoted strings as term seperators, not explicit ...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,10 @@ Usage
     >>> DictFormater().visit(node_tree)
     [('author', 'John Smith'), ('type', 'book')]
 
+    >>> node_tree = grammar.parse('author:"John Smith" type:book title:" A Title   With Spaces"')
+    >>> DictFormater().visit(node_tree)
+    [('author', 'John Smith'), ('type', 'book'), ('title', 'A Title With Spaces')]
+
 Test
 ----
 

--- a/cnxquerygrammar/query.peg
+++ b/cnxquerygrammar/query.peg
@@ -8,9 +8,9 @@ field = field_name ":" ( quoted_term / term )
 field_name = ~"[a-zA-Z_][a-zA-Z0-9]*"
 
 
-term = ~'[^"\s]*'
+term = ~'[^"\s]+'
 
-quoted_term = quote ( space / term )* quote
+quoted_term = quote ( term / space )* quote
 
 quote = '"'
 

--- a/cnxquerygrammar/query_parser.py
+++ b/cnxquerygrammar/query_parser.py
@@ -34,7 +34,12 @@ class DictFormater(NodeVisitor):
 
     def visit_quoted_term(self, node, visited_children):
         """Quoted terms are text that shouldn't be separated"""
-        return ('text', node.children[1].text,)
+        termtexts = []
+        for child in visited_children:
+            if child: # Non-empty child is a list of all terms
+                for term in child:
+                    termtexts.append(term[0][1])
+        return ('text', ' '.join(termtexts))
 
     def visit_term(self, node, visited_children):
         """terms are standalone text values."""


### PR DESCRIPTION
...characters. In preference to doing this in the client.
